### PR TITLE
#include Arduino.h dependency

### DIFF
--- a/src/DDS.h
+++ b/src/DDS.h
@@ -1,6 +1,7 @@
 #ifndef _DDS_H_
 #define _DDS_H_
 
+#include <Arduino.h>
 #include <avr/pgmspace.h>
 
 // Use pin 3 for PWM? If not defined, use pin 11


### PR DESCRIPTION
Previously the library relied on the Arduino IDE doing the automatic insertion of #include <Arduino.h> in the sketch before #include <DDS.h>. In some IDE versions that does not happen and there is no guarantee of that behavior in future IDE versions thus for backwards and forwards compatibility it's best to simply add an #include directive to DDS.h.