### PR TITLE
Remove default argument from function definition

### DIFF
--- a/src/DDS.cpp
+++ b/src/DDS.cpp
@@ -45,7 +45,7 @@ void DDS::stop() {
   TCCR2B = 0;
 }
 
-void DDS::startPhaseAccumulator(bool use_only_timer_2 = false){
+void DDS::startPhaseAccumulator(bool use_only_timer_2){
     timer2only = use_only_timer_2;
 
   if(timer2only){


### PR DESCRIPTION
Default arguments should only be specified in function prototypes, not in the function definition. This caused compilation of the library to fail for Arduino AVR Boards 1.6.11 or earlier. It does not cause compilation to fail for Arduino AVR Boards 1.6.12 and newer only because the `-fpermissive` compiler flag was added, which downgrades this to an error. It has been stated that flag may be removed in the future:
https://github.com/arduino/ArduinoCore-avr/commit/06868f4cd39a9dba82b5014d1208feb1e1f0d750
So this change is necessary for both backwards and forwards compatibility. Also, some hardware packages other than Arduino AVR Boards do not have `-fpermissive` and so this is an error when compiled for those boards.

Even with current versions it fixes a warning, which is always wise to do.

Fixes https://github.com/EnhancedRadioDevices/DDS/issues/3

CC: @pggood @mogar